### PR TITLE
Support for editing any room via optional "edit" command argument

### DIFF
--- a/src/config.yml
+++ b/src/config.yml
@@ -2,6 +2,7 @@ messages:
   errors:
     alreadyexist: '&c[Error] The dungeon %dungeon% already exist!' 
     doesnotexist: '&c[Error] The dungeon %dungeon% doesn’t exist!'
+    roomnotexist: '&c[Error] The dungeon room #%room% doesn’t exist!'
     duplicatename: '&c[Error] Unable to load folder &4%folder%&c, another dungeon with this name is already in use. This dungeon is no longer loaded. You can re-import it with the command &4/dungeon create %folder%&c.'
     exitnotset: '&c[Error] Firstly, you need to define an exit before being able to add a room. Use &4/dungeon setexit&c.'
     exitincorectlocation: '&c[Error] The exit can only be defined on the north side of the selection (&4Z= %z%&c needed).'

--- a/src/fr/foxelia/proceduraldungeon/commands/DungeonCommand.java
+++ b/src/fr/foxelia/proceduraldungeon/commands/DungeonCommand.java
@@ -88,7 +88,7 @@ public class DungeonCommand implements CommandExecutor {
 				}
 				if(sender.hasPermission("proceduraldungeon.admin.edit") && isPlayer) {
 					sender.sendMessage(ChatColor.translateAlternateColorCodes('&', Main.getHelpMessage("helpcmd")
-							.replace("%cmd%", "dungeon edit {dungeonname}")
+							.replace("%cmd%", "dungeon edit {dungeonname} (roomnumber)")
 							.replace("%info%", Main.getHelpMessage("info.edit"))));
 				}
 				if(sender.hasPermission("proceduraldungeon.admin.addroom") && isPlayer) {
@@ -413,7 +413,7 @@ public class DungeonCommand implements CommandExecutor {
 					return false;					
 				}
 				
-				if(args.length >= 2) {
+				if(args.length == 2) {
 					Player p = (Player) sender;
 					
 					if(!Main.getDungeons().containsKey(args[1].toLowerCase())) {
@@ -433,6 +433,21 @@ public class DungeonCommand implements CommandExecutor {
 					GUI gui = new GUIManager().createDungeonGUI(dungeon);
 					Main.getGUIs().add(gui);
 					p.openInventory(gui.getInventory());
+					return true;
+				} 
+				if (args.length >= 3) {
+					Player p = (Player) sender;
+					
+					DungeonManager dungeon = Main.getDungeons().get(args[1].toLowerCase());
+					try {
+					GUI gui = new GUIManager().createDungeonGUI(dungeon);
+					Room room = gui.getDungeon().getDungeonRooms().getRooms().get(Integer.valueOf(args[2]));
+					GUI newgui = new GUIManager().createRoomGUI(gui.getDungeon(), room);
+					Main.getGUIs().add(newgui);
+					p.openInventory(newgui.getInventory());
+					} catch(IndexOutOfBoundsException | NumberFormatException e) {
+						p.sendMessage(ChatColor.translateAlternateColorCodes('&', Main.getErrorMessage("roomnotexist").replace("%room%", args[2])));
+					}
 					return true;
 				}
 /*


### PR DESCRIPTION
Add an optional "room" argument for the "/dungeon edit {dungeonname}" command

It looks like this "/dungeon edit {dungeonname} (roomnumber)" 

If (roomnumber) is set, then instead of opening the GUI, it will directly edit the specified room. **This means that even if you have over 36 room, they can all still be configured**